### PR TITLE
Add UDP listener and HuaShu message parser

### DIFF
--- a/src/main/java/com/wx/udp/HuaShuMessage.java
+++ b/src/main/java/com/wx/udp/HuaShuMessage.java
@@ -1,0 +1,121 @@
+package com.wx.udp;
+
+import java.util.Arrays;
+
+/**
+ * Representation of a single STRU_MSG_ITEM message from the HuaShu RuiXun
+ * protocol. The structure mirrors the C struct described in the integration
+ * documentation.
+ */
+public class HuaShuMessage {
+
+    private byte productionLineId; // u8ProductionLineId
+    private byte macId;            // u8MacId
+    private byte moduleId;         // u8ModuleId
+    private byte cardId;           // u8CardId
+    private int type;              // s32Type
+    private int index;             // s32Index
+    private int value;             // s32Value
+    private final int[] data = new int[2]; // as32Data[2]
+    private int[] in;   // as32In[96] when type == 0
+    private int[] pos;  // as32Pos[16] when type == 0
+
+    public byte getProductionLineId() {
+        return productionLineId;
+    }
+
+    public void setProductionLineId(byte productionLineId) {
+        this.productionLineId = productionLineId;
+    }
+
+    public byte getMacId() {
+        return macId;
+    }
+
+    public void setMacId(byte macId) {
+        this.macId = macId;
+    }
+
+    public byte getModuleId() {
+        return moduleId;
+    }
+
+    public void setModuleId(byte moduleId) {
+        this.moduleId = moduleId;
+    }
+
+    public byte getCardId() {
+        return cardId;
+    }
+
+    public void setCardId(byte cardId) {
+        this.cardId = cardId;
+    }
+
+    public int getType() {
+        return type;
+    }
+
+    public void setType(int type) {
+        this.type = type;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public void setIndex(int index) {
+        this.index = index;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public void setValue(int value) {
+        this.value = value;
+    }
+
+    public int[] getData() {
+        return data;
+    }
+
+    public int[] getIn() {
+        return in;
+    }
+
+    public void setIn(int[] in) {
+        this.in = in;
+    }
+
+    public int[] getPos() {
+        return pos;
+    }
+
+    public void setPos(int[] pos) {
+        this.pos = pos;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("HuaShuMessage{")
+          .append("productionLineId=").append(productionLineId)
+          .append(", macId=").append(macId)
+          .append(", moduleId=").append(moduleId)
+          .append(", cardId=").append(cardId)
+          .append(", type=").append(type)
+          .append(", index=").append(index)
+          .append(", value=").append(value)
+          .append(", data=").append(Arrays.toString(data));
+        if (in != null) {
+            sb.append(", in=").append(Arrays.toString(in));
+        }
+        if (pos != null) {
+            sb.append(", pos=").append(Arrays.toString(pos));
+        }
+        sb.append('}');
+        return sb.toString();
+    }
+}
+

--- a/src/main/java/com/wx/udp/HuaShuMessageParser.java
+++ b/src/main/java/com/wx/udp/HuaShuMessageParser.java
@@ -1,0 +1,48 @@
+package com.wx.udp;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Utility class for parsing binary payloads into {@link HuaShuMessage} objects.
+ */
+public final class HuaShuMessageParser {
+
+    private HuaShuMessageParser() {
+    }
+
+    /**
+     * Parse a payload without framing (i.e. without the F0F0 length header and
+     * trailing zeros) into a {@link HuaShuMessage}.
+     *
+     * @param payload binary payload
+     * @return parsed message
+     */
+    public static HuaShuMessage parse(byte[] payload) {
+        ByteBuffer buffer = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN);
+        HuaShuMessage msg = new HuaShuMessage();
+        msg.setProductionLineId(buffer.get());
+        msg.setMacId(buffer.get());
+        msg.setModuleId(buffer.get());
+        msg.setCardId(buffer.get());
+        msg.setType(buffer.getInt());
+        msg.setIndex(buffer.getInt());
+        msg.setValue(buffer.getInt());
+        msg.getData()[0] = buffer.getInt();
+        msg.getData()[1] = buffer.getInt();
+        if (msg.getType() == 0) {
+            int[] in = new int[96];
+            for (int i = 0; i < in.length; i++) {
+                in[i] = buffer.getInt();
+            }
+            msg.setIn(in);
+            int[] pos = new int[16];
+            for (int i = 0; i < pos.length; i++) {
+                pos[i] = buffer.getInt();
+            }
+            msg.setPos(pos);
+        }
+        return msg;
+    }
+}
+

--- a/src/main/java/com/wx/udp/UdpServer.java
+++ b/src/main/java/com/wx/udp/UdpServer.java
@@ -1,0 +1,75 @@
+package com.wx.udp;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Simple UDP server that listens on port 8671 for HuaShu RuiXun messages and
+ * logs them to the console.
+ */
+@Component
+public class UdpServer {
+
+    private static final int PORT = 8671;
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private volatile boolean running = true;
+
+    @PostConstruct
+    public void start() {
+        executor.execute(this::listen);
+    }
+
+    @PreDestroy
+    public void stop() {
+        running = false;
+        executor.shutdownNow();
+    }
+
+    private void listen() {
+        try (DatagramSocket socket = new DatagramSocket(PORT)) {
+            byte[] buf = new byte[1024 * 10];
+            DatagramPacket packet = new DatagramPacket(buf, buf.length);
+            while (running) {
+                socket.receive(packet);
+                int len = packet.getLength();
+                byte[] data = Arrays.copyOf(packet.getData(), len);
+                process(data);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void process(byte[] data) {
+        if (data.length < 8) {
+            return; // invalid
+        }
+        if (data[0] != (byte) 0xF0 || data[1] != (byte) 0xF0) {
+            return; // wrong header
+        }
+        ByteBuffer header = ByteBuffer.wrap(data, 2, 2).order(ByteOrder.LITTLE_ENDIAN);
+        int payloadLen = header.getShort() & 0xFFFF;
+        if (payloadLen + 8 != data.length) {
+            return; // length mismatch
+        }
+        for (int i = data.length - 4; i < data.length; i++) {
+            if (data[i] != 0) {
+                return; // invalid trailer
+            }
+        }
+        byte[] payload = Arrays.copyOfRange(data, 4, 4 + payloadLen);
+        HuaShuMessage msg = HuaShuMessageParser.parse(payload);
+        System.out.println("Received message: " + msg);
+    }
+}
+


### PR DESCRIPTION
## Summary
- define `HuaShuMessage` structure to mirror protocol fields
- add `HuaShuMessageParser` to decode little-endian binary payloads
- implement `UdpServer` listening on port 8671 to receive and log parsed messages

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ac012ebffc8330bf587bb7d8d15327