### PR TITLE
feat: record last device data

### DIFF
--- a/src/main/java/com/wx/storage/LastDataService.java
+++ b/src/main/java/com/wx/storage/LastDataService.java
@@ -1,0 +1,79 @@
+package com.wx.storage;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 将每个产线每台设备的最后一条数据持久化到文件中。
+ */
+@Component
+public class LastDataService {
+
+    /** 内存中的数据缓存：port -> (line-device -> data) */
+    private final Map<Integer, Map<String, Object>> cache = new ConcurrentHashMap<>();
+    /** JSON 序列化工具 */
+    private final ObjectMapper mapper = new ObjectMapper();
+    /** 数据文件路径 */
+    private final Path filePath;
+
+    public LastDataService(@Value("${lastdata.file:}") String path) {
+        if (path == null || path.isBlank()) {
+            this.filePath = Paths.get(System.getProperty("user.home"), "last-data.json");
+        } else {
+            this.filePath = Paths.get(path);
+        }
+    }
+
+    /** 启动时尝试读取已有的数据文件 */
+    @PostConstruct
+    public void init() {
+        if (Files.exists(filePath)) {
+            try {
+                Map<Integer, Map<String, Object>> fromFile = mapper.readValue(
+                        filePath.toFile(), new TypeReference<>() {});
+                cache.putAll(fromFile);
+            } catch (IOException e) {
+                // 读取失败时忽略，使用空缓存
+            }
+        }
+    }
+
+    /**
+     * 保存最新数据并写入文件。
+     *
+     * @param port    数据来源端口
+     * @param lineId  产线ID
+     * @param deviceId 设备ID
+     * @param data    原始数据对象
+     */
+    public void save(int port, int lineId, int deviceId, Object data) {
+        cache.computeIfAbsent(port, p -> new ConcurrentHashMap<>())
+                .put(lineId + "-" + deviceId, data);
+        try {
+            Files.createDirectories(filePath.getParent());
+            mapper.writeValue(filePath.toFile(), cache);
+        } catch (IOException e) {
+            // 写入失败时忽略
+        }
+    }
+
+    /**
+     * 获取所有缓存的数据。
+     *
+     * @return 内存中的全部数据
+     */
+    public Map<Integer, Map<String, Object>> getAll() {
+        return cache;
+    }
+}
+

--- a/src/main/java/com/wx/web/LastDataController.java
+++ b/src/main/java/com/wx/web/LastDataController.java
@@ -1,0 +1,31 @@
+package com.wx.web;
+
+import com.wx.storage.LastDataService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/**
+ * 提供查询所有产线所有设备最后一条数据的接口。
+ */
+@RestController
+public class LastDataController {
+
+    private final LastDataService service;
+
+    public LastDataController(LastDataService service) {
+        this.service = service;
+    }
+
+    /**
+     * 获取所有缓存的最后一条数据。
+     *
+     * @return port -> (line-device -> data)
+     */
+    @GetMapping("/last-data")
+    public Map<Integer, Map<String, Object>> all() {
+        return service.getAll();
+    }
+}
+

--- a/src/main/java/com/wx/websocket/DataWebSocketHandler.java
+++ b/src/main/java/com/wx/websocket/DataWebSocketHandler.java
@@ -2,7 +2,6 @@ package com.wx.websocket;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
@@ -18,7 +17,6 @@ import java.util.concurrent.ConcurrentHashMap;
  * 简单的 WebSocket 处理器，维护当前连接的会话，并广播包含 UDP 来源端口
  * 与解析数据的 JSON 消息。
  */
-@Component
 public class DataWebSocketHandler extends TextWebSocketHandler {
 
     /** 保存所有活跃的 WebSocket 会话 */

--- a/src/main/java/com/wx/websocket/WebSocketConfig.java
+++ b/src/main/java/com/wx/websocket/WebSocketConfig.java
@@ -1,27 +1,44 @@
 package com.wx.websocket;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
 
 /**
- * 将 {@link DataWebSocketHandler} 注册到 "/ws" 端点。
+ * 注册两个 WebSocket 端点，分别用于8677(运动控制)和8671(设备数据)。
  */
 @Configuration
 @EnableWebSocket
 public class WebSocketConfig implements WebSocketConfigurer {
 
-    /** 注入的 WebSocket 处理器 */
-    private final DataWebSocketHandler handler;
+    private final DataWebSocketHandler motionHandler;
+    private final DataWebSocketHandler deviceHandler;
 
-    public WebSocketConfig(DataWebSocketHandler handler) {
-        this.handler = handler;
+    public WebSocketConfig(@Qualifier("motionHandler") DataWebSocketHandler motionHandler,
+                           @Qualifier("deviceHandler") DataWebSocketHandler deviceHandler) {
+        this.motionHandler = motionHandler;
+        this.deviceHandler = deviceHandler;
+    }
+
+    /** 8677端口对应的 WebSocket 处理器 */
+    @Bean("motionHandler")
+    public DataWebSocketHandler motionHandler() {
+        return new DataWebSocketHandler();
+    }
+
+    /** 8671端口对应的 WebSocket 处理器 */
+    @Bean("deviceHandler")
+    public DataWebSocketHandler deviceHandler() {
+        return new DataWebSocketHandler();
     }
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(handler, "/ws").setAllowedOrigins("*");
+        registry.addHandler(motionHandler, "/ws/motion").setAllowedOrigins("*");
+        registry.addHandler(deviceHandler, "/ws/device").setAllowedOrigins("*");
     }
 }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,6 @@
 # 应用服务 WEB 访问端口
 server.port=8080
 
+# 存储最后一条数据的文件路径，留空则默认存放在用户目录下
+# lastdata.file=/path/to/last-data.json
+


### PR DESCRIPTION
## Summary
- store last UDP payload per line and device in configurable JSON file
- expose `/last-data` endpoint to list latest device messages
- add separate WebSocket endpoints for motion control and device data

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2d8da7588330aa87ed3429ed7f67